### PR TITLE
feat(shop): implement shop page MVP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
+  turbopack: {
+  root: process.cwd(),
+},
 };
 
 export default nextConfig;

--- a/src/app/shop/page.module.css
+++ b/src/app/shop/page.module.css
@@ -156,6 +156,13 @@
   letter-spacing: 0.4px;
 }
 
+.cardButton:disabled {
+  background-color: #7ea27a;
+  cursor: not-allowed;
+  letter-spacing: 0;
+  opacity: 0.9;
+}
+
 @media (max-width: 1024px) {
   .grid,
   .productGrid {

--- a/src/app/shop/page.module.css
+++ b/src/app/shop/page.module.css
@@ -1,0 +1,194 @@
+.page,
+.container {
+  width: 100%;
+  padding: 2rem 1.25rem 4rem;
+}
+
+.header,
+.hero,
+.introBlock {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.eyebrow {
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-3);
+  margin-bottom: 0.85rem;
+}
+
+.title,
+.heading {
+  font-size: 2.75rem;
+  color: var(--primary-color);
+  margin-bottom: 0.75rem;
+  letter-spacing: -0.5px;
+}
+
+.subtitle,
+.intro,
+.descriptionText,
+.subheading {
+  max-width: 720px;
+  margin: 0 auto;
+  color: var(--primary-color);
+  opacity: 0.85;
+  line-height: 1.7;
+  font-size: 1.05rem;
+}
+
+.section {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.grid,
+.productGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+.card,
+.productCard {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: white;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 18px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.06);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card:hover,
+.productCard:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 35px rgba(52, 88, 48, 0.12);
+}
+
+.imageWrap,
+.imageWrapper,
+.imageContainer {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  background: rgba(250, 215, 198, 0.35);
+}
+
+.image {
+  object-fit: cover;
+}
+
+.content,
+.info,
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1.15rem;
+}
+
+.name,
+.productName {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  line-height: 1.35;
+  color: var(--primary-color);
+}
+
+.description,
+.productDescription {
+  margin: 0;
+  color: var(--primary-color);
+  opacity: 0.8;
+  line-height: 1.6;
+  font-size: 0.98rem;
+  flex-grow: 1;
+}
+
+.price,
+.productPrice {
+  flex-shrink: 0;
+  color: var(--accent-3);
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.titleRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.actions {
+  margin-top: 0.25rem;
+}
+
+.button,
+.cta,
+.actionButton,
+.cardButton {
+  display: inline-block;
+  text-decoration: none;
+  text-align: center;
+  background-color: var(--accent-3);
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, letter-spacing 0.2s ease;
+}
+
+.button:hover,
+.cta:hover,
+.actionButton:hover,
+.cardButton:hover {
+  background-color: var(--accent-2);
+  letter-spacing: 0.4px;
+}
+
+@media (max-width: 1024px) {
+  .grid,
+  .productGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .page,
+  .container {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .title,
+  .heading {
+    font-size: 2.1rem;
+  }
+
+  .grid,
+  .productGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .titleRow {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+
+  .subtitle,
+  .intro,
+  .descriptionText,
+  .subheading {
+    font-size: 1rem;
+  }
+}

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -81,8 +81,13 @@ export default function ShopPage() {
 
                 <p className={styles.description}>{product.description}</p>
 
-                <button type="button" className={styles.cardButton}>
-                  View Details
+                <button
+                  type="button"
+                  className={styles.cardButton}
+                  disabled
+                  aria-disabled="true"
+                >
+                  Details Coming Soon
                 </button>
               </div>
             </article>

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,3 +1,94 @@
+import Image from "next/image";
+import styles from "./page.module.css";
+
+const products = [
+  {
+    id: 1,
+    name: "Walnut Accent Chair",
+    price: "$189",
+    description: "A clean handcrafted chair with a warm walnut finish for modern living spaces.",
+    image: "/images/hero-image.jpg",
+  },
+  {
+    id: 2,
+    name: "Rustic Coffee Table",
+    price: "$245",
+    description: "Solid wood center table built to bring warmth and character into the room.",
+    image: "/images/hero-image.jpg",
+  },
+  {
+    id: 3,
+    name: "Floating Wall Shelf",
+    price: "$72",
+    description: "Minimal shelf piece designed for décor, books, and small everyday items.",
+    image: "/images/hero-image.jpg",
+  },
+  {
+    id: 4,
+    name: "Dining Bench",
+    price: "$158",
+    description: "Hand-finished bench seating with a sturdy frame and timeless farmhouse feel.",
+    image: "/images/hero-image.jpg",
+  },
+  {
+    id: 5,
+    name: "Bedside Table",
+    price: "$129",
+    description: "Compact bedside storage piece crafted for both style and daily function.",
+    image: "/images/hero-image.jpg",
+  },
+  {
+    id: 6,
+    name: "Entryway Console",
+    price: "$210",
+    description: "Slim handcrafted console table ideal for hallways, foyers, and display décor.",
+    image: "/images/hero-image.jpg",
+  },
+];
+
 export default function ShopPage() {
-  return <main>Shop Page</main>;
+  return (
+    <main className={styles.page}>
+      <section className={styles.hero}>
+        <p className={styles.eyebrow}>Handcrafted Collection</p>
+        <h1 className={styles.heading}>Shop Our Featured Pieces</h1>
+        <p className={styles.subheading}>
+          Explore a curated set of handcrafted furniture and décor pieces built
+          for warmth, function, and timeless style.
+        </p>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.grid}>
+          {products.map((product) => (
+            <article key={product.id} className={styles.card}>
+              <div className={styles.imageWrap}>
+                <Image
+                  src={product.image}
+                  alt={product.name}
+                  fill
+                  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                  loading={product.id === 1 ? "eager" : "lazy"}
+                  className={styles.image}
+                />
+              </div>
+
+              <div className={styles.cardBody}>
+                <div className={styles.titleRow}>
+                  <h2 className={styles.productName}>{product.name}</h2>
+                  <span className={styles.price}>{product.price}</span>
+                </div>
+
+                <p className={styles.description}>{product.description}</p>
+
+                <button type="button" className={styles.cardButton}>
+                  View Details
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
 }


### PR DESCRIPTION
This PR implements the initial shop page for Handcrafted Haven.

Included:
- fixed the /shop route rendering issue
- added the shop page layout and product card grid
- styled the page to align with existing branding
- added responsive image sizing and eager loading for the first visible product image

Validated locally:
- npm run dev
- tested /shop in browser